### PR TITLE
[DEV-22, DEV-27] Delete preview site command

### DIFF
--- a/pkg/cms_watcher.go
+++ b/pkg/cms_watcher.go
@@ -56,6 +56,9 @@ func (w cmsWatcher) OnDelete(obj interface{}) {
 }
 
 func (w cmsWatcher) enqeueueMsg(obj metav1.Object) {
+	if !obj.GetDeletionTimestamp().IsZero() {
+		return
+	}
 	msg, pr, err := w.previewSiteUpdate(obj)
 	if err != nil {
 		klog.Errorf("dropping event for sc %v/%v: %v", obj.GetNamespace(), obj.GetName(), err)

--- a/pkg/responses.go
+++ b/pkg/responses.go
@@ -2,6 +2,7 @@ package pkg
 
 import (
 	"fmt"
+	"strings"
 
 	common "github.com/drud/cms-common/api/v1beta1"
 	siteapi "github.com/drud/ddev-live-sdk/golang/pkg/site/apis/site/v1beta1"
@@ -14,16 +15,30 @@ const (
 	commandPrefix = "/ddev-live-"
 
 	// Ping/pong
-	ping = "/ddev-live-ping"
+	Ping = "/ddev-live-ping"
+
+	// Print help message
+	Help = "/ddev-live-help"
 
 	// Create preview site
-	previewSite = "/ddev-live-preview-site"
+	PreviewSite = "/ddev-live-preview-site"
+
+	// Delete preview site
+	DeletePreviewSite = "/ddev-live-delete-preview-site"
 )
 
 // These strings contain responses for `/ddev-live-*` commands in PR/MR comments
 const (
 	// Pong
 	pong = "ddev-live-pong"
+
+	// Help message how to use the repo chat bot
+	helpResponse = "**DDEV-Live preview bot** available commands\n" +
+		"```\n" +
+		Help + " - displays this help message\n" +
+		PreviewSite + " - creates preview site cloning origin branch\n" +
+		DeletePreviewSite + " - deletes the preview site\n" +
+		"```"
 
 	// Generic error when site cloning failed. We don't want to expose internal details on PR comments,
 	// logs will contain more information about what failed
@@ -45,6 +60,16 @@ const (
 $ ddev-live describe clone %v
 $ ddev-live describe site %v
 ` + "```"
+
+	// Deletion of `SiteClone` failed for a specific origin site,
+	// logs will contain more information about what failed
+	deleteSiteError = "**Internal error** failed to delete preview site `%v` in `%v`"
+
+	// Deletion of `SiteClone` in progress
+	deleteSite = "**Deleting preview site** `%v` in `%v`"
+
+	// No site to be deleted
+	deleteSiteNone = "**No preview site to be deleted**"
 )
 
 type siteStatus struct {
@@ -84,4 +109,14 @@ func previewCreating(sc *siteapi.SiteClone, site siteStatus) string {
 		return fmt.Sprintf("**Creating preview site** %v\n**Status:** Site %v is waiting for preview URL", msg, sn)
 	}
 	return fmt.Sprintf("**Preview site created** %v\n**Preview URL:** %v", msg, site.webStatus.URLs[0])
+}
+
+func isBot(msg string) bool {
+	if msg == helpResponse {
+		return true
+	}
+	if strings.HasPrefix(msg, deleteSiteNone) {
+		return true
+	}
+	return false
 }

--- a/pkg/siteclone_watcher.go
+++ b/pkg/siteclone_watcher.go
@@ -41,6 +41,9 @@ func (w scWatcher) OnDelete(obj interface{}) {
 }
 
 func (w scWatcher) enqueueMsg(sc *siteapi.SiteClone) {
+	if !sc.DeletionTimestamp.IsZero() {
+		return
+	}
 	if sc.Annotations == nil || sc.Annotations[botAnnotation] != w.kubeClients.annotation {
 		return
 	}


### PR DESCRIPTION
This implements two new commands and two triggers:
1) `/ddev-live-help` - a command that displays how to use the bot. This is also triggered on PR open to give user information how to use the bot. It should probably also contain link to the docs, when we have
documentation.
2) `/ddev-live-delete-preview-site` - a command that deletes preview sites related to a specific PR. This is also triggered on PR close.

issues: https://ddevhq.atlassian.net/browse/DEV-27, https://ddevhq.atlassian.net/browse/DEV-22
vendored in: https://github.com/drud/gitlab-webhook-server/pull/12, https://github.com/drud/github-operator/pull/89