### PR TITLE
[DEV-22, DEV-27] Add verbose and quite options to PR triggers

### DIFF
--- a/pkg/responses.go
+++ b/pkg/responses.go
@@ -17,14 +17,20 @@ const (
 	// Ping/pong
 	Ping = "/ddev-live-ping"
 
-	// Print help message
+	// Print help message for users calling the command
 	Help = "/ddev-live-help"
+
+	// Print help message on PR open, only when applicable
+	HelpOnPROpen = "/ddev-live-help-on-pr-open"
 
 	// Create preview site
 	PreviewSite = "/ddev-live-preview-site"
 
-	// Delete preview site
+	// Delete preview site, always provides verbose response event when no site exists
 	DeletePreviewSite = "/ddev-live-delete-preview-site"
+
+	// Close preview site, provides output only in case a preview site existed. This is for PR closing.
+	ClosePreviewSite = "/ddev-live-close-preview-site"
 )
 
 // These strings contain responses for `/ddev-live-*` commands in PR/MR comments


### PR DESCRIPTION
Followup to: https://github.com/drud/repo-chat-bot/pull/4
this changes the PR triggers to display output only when applicable 
- the help message when there is some origin to clone preview site from
- the delete message when there is a preview site do be deleted

This prevents unnecessary confusing messages when there is no action.