### PR TITLE
[DEV-20] Notification when preview site is deleted

### DIFF
--- a/pkg/bot.go
+++ b/pkg/bot.go
@@ -439,3 +439,14 @@ func (k kubeClients) previewSiteUpdate(obj metav1.Object) (string, int, error) {
 	}
 	return "", 0, nil
 }
+
+func (k kubeClients) deletePreviewSiteUpdate(sc *siteapi.SiteClone) (string, int, error) {
+	if sc.Annotations[botAnnotation] != k.annotation {
+		return "", 0, nil
+	}
+	pr, err := strconv.Atoi(sc.Annotations[prAnnotation])
+	if err != nil {
+		return previewGenericError, 0, fmt.Errorf("failed to parse %q annotation: %v", prAnnotation, err)
+	}
+	return fmt.Sprintf(deletedSite, sc.Spec.Clone.Name, sc.Namespace), pr, nil
+}

--- a/pkg/lock.go
+++ b/pkg/lock.go
@@ -1,0 +1,47 @@
+package pkg
+
+import (
+	"fmt"
+	"sync"
+)
+
+type PRLock struct {
+	l *sync.Mutex
+	m map[string]*lockEntry
+}
+
+type lockEntry struct {
+	l *sync.Mutex
+	c int
+}
+
+func NewPRLock() *PRLock {
+	return &PRLock{
+		l: &sync.Mutex{},
+		m: make(map[string]*lockEntry),
+	}
+}
+
+func (l *PRLock) Lock(repo string, pr int) {
+	l.l.Lock()
+	key := fmt.Sprintf("%v/%v", repo, pr)
+	if e, ok := l.m[key]; ok {
+		e.c += 1
+	} else {
+		l.m[key] = &lockEntry{c: 1, l: &sync.Mutex{}}
+	}
+	l.l.Unlock()
+	l.m[key].l.Lock()
+}
+
+func (l *PRLock) Unlock(repo string, pr int) {
+	l.l.Lock()
+	key := fmt.Sprintf("%v/%v", repo, pr)
+	e := l.m[key]
+	e.c -= 1
+	if e.c < 1 {
+		delete(l.m, key)
+	}
+	l.l.Unlock()
+	e.l.Unlock()
+}

--- a/pkg/responses.go
+++ b/pkg/responses.go
@@ -76,6 +76,9 @@ $ ddev-live describe site %v
 
 	// No site to be deleted
 	deleteSiteNone = "**No preview site to be deleted**"
+
+	// The `SiteClone` was deleted, child resources will be garbage collected
+	deletedSite = "**Deleted preview site** `%v` in `%v`"
 )
 
 type siteStatus struct {


### PR DESCRIPTION
This implements a final notification when the informer receives event that `SiteClone` has been deleted. It expects that garbage collection in kubernetes works and we can claim the site properly cleaned up. This should be validated by https://ddevhq.atlassian.net/browse/DEV-104.

This also implements a map of locks per pull request. Sometimes the deletion is faster than sending information about the fact bot is trying to delete a preview site. Without locking, it was possible that bot first responded that "site is deleted" and then the information about "deleting a site" as implemented in https://github.com/drud/repo-chat-bot/pull/4.

issue: https://ddevhq.atlassian.net/browse/DEV-20