### PR TITLE
[DEV-24] Build error notifications

### DIFF
--- a/config/rbac.yaml
+++ b/config/rbac.yaml
@@ -25,3 +25,13 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - core
+  - ""
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - list
+  - watch

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,9 @@ module github.com/drud/repo-chat-bot
 go 1.15
 
 require (
-	github.com/drud/cms-common v0.0.5-0.20201012075554-269eb86a7aaf
-	github.com/drud/ddev-live-sdk v0.2.8-endor-rc4
+	github.com/drud/cms-common v0.0.5-0.20201102102539-d387b6e59d97
+	github.com/drud/ddev-live-sdk v0.2.8-endor-rc4.0.20201102125433-7a3bdc3eba01
+	k8s.io/api v0.17.9
 	k8s.io/apimachinery v0.17.9
 	k8s.io/client-go v0.17.9
 	k8s.io/klog v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -135,10 +135,12 @@ github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZ
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/drud/cms-common v0.0.5-0.20201012075554-269eb86a7aaf h1:UqDMXgV6Bdo2X4y0gO2OOP7gKA2t8Vha1iRU7kJNa/0=
 github.com/drud/cms-common v0.0.5-0.20201012075554-269eb86a7aaf/go.mod h1:q1yByEYoYLpMZHjgao734yV0DvkDhvKD7A+rLHY/jZA=
-github.com/drud/cms-common v0.0.6 h1:ejGhqrBHHTEFHpMX+CjnMf1qfubrg/Q/m4ytxVoJcpk=
-github.com/drud/ddev-live-sdk v0.2.8-endor-rc4 h1:yGyyhOLpd4NhjnDeynzgFh7iFRezRX8VAK3oEzl4Bzk=
-github.com/drud/ddev-live-sdk v0.2.8-endor-rc4/go.mod h1:md0iz2pfuvBAzaYUk3DeZFZkOsTJNsBgR/MWBueMDUY=
+github.com/drud/cms-common v0.0.5-0.20201102102539-d387b6e59d97 h1:YywE8RlkMmlET/ny/4HSv7T1ZqpZPHlxhKyOt2jh5Fc=
+github.com/drud/cms-common v0.0.5-0.20201102102539-d387b6e59d97/go.mod h1:muiywzGnitneOqXJIV3juLCWKVe2QnweL8YmEjp8+SQ=
+github.com/drud/ddev-live-sdk v0.2.8-endor-rc4.0.20201102125433-7a3bdc3eba01 h1:5UD5qK51yuM33kpcc2rvcjKSgaME7X87sk14oS4eM9c=
+github.com/drud/ddev-live-sdk v0.2.8-endor-rc4.0.20201102125433-7a3bdc3eba01/go.mod h1:md0iz2pfuvBAzaYUk3DeZFZkOsTJNsBgR/MWBueMDUY=
 github.com/drud/site-operator/pkg/apis v0.0.21/go.mod h1:ZhOJCASimyWl/fdthd8wg9lN5erEBwhN9CFi0quZW+0=
+github.com/drud/site-operator/pkg/apis v0.0.25-rc3/go.mod h1:ZhOJCASimyWl/fdthd8wg9lN5erEBwhN9CFi0quZW+0=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=

--- a/pkg/responses.go
+++ b/pkg/responses.go
@@ -42,7 +42,7 @@ const (
 	helpResponse = "**DDEV-Live preview bot** available commands\n" +
 		"```\n" +
 		Help + " - displays this help message\n" +
-		PreviewSite + " - creates preview site cloning origin branch\n" +
+		PreviewSite + " - trigger preview site creation or display its status\n" +
 		DeletePreviewSite + " - deletes the preview site\n" +
 		"```"
 
@@ -63,8 +63,8 @@ const (
 	// using referenced origin site
 	previewCreatingMsg = "`%v`" + ` in ` + "`%v`" + `. This will be kept up to date with site's current status. You can also use the ` + "`ddev-live`" + ` CLI to get more information about the preview site creation progress:
 ` + "```" + `
-$ ddev-live describe clone %v
-$ ddev-live describe site %v
+$ ddev-live describe clone %v/%v
+$ ddev-live describe site %v/%v
 ` + "```"
 
 	// Deletion of `SiteClone` failed for a specific origin site,
@@ -79,11 +79,40 @@ $ ddev-live describe site %v
 
 	// The `SiteClone` was deleted, child resources will be garbage collected
 	deletedSite = "**Deleted preview site** `%v` in `%v`"
+
+	// Site build error
+	siteBuildError = "**Failed building preview site** `%v` in `%v`. %v. For additional information please check the status using `ddev-live`\n" +
+		"```\n" +
+		"$ ddev-live describe clone %v/%v\n" +
+		"$ ddev-live describe site %v/%v\n" +
+		"```\n"
+
+	// Optionally we try to provide site build logs if available for siteBuildError
+	siteBuildErrorLog = "<details><summary>error log</summary>\n" +
+		"<p>\n" +
+		"\n\n" +
+		"```\n" +
+		"%v\n" +
+		"```\n\n" +
+		"</p>\n" +
+		"</details>\n"
+
+	// Error message when bot fails to get build logs for a site
+	siteBuildLogFetchFailed = "failed fetching site build logs"
+
+	// Error message when bot didn't find any build pods for a site
+	noSiteBuilds = "found 0 builds"
 )
 
 type siteStatus struct {
 	conditions []common.Condition
 	webStatus  common.WebStatus
+}
+
+type buildStatus struct {
+	failed    bool
+	failState string
+	logs      string
 }
 
 func getCommonStatus(t3 *typo3api.Typo3Site) siteStatus {
@@ -100,8 +129,16 @@ func getCommonStatus(t3 *typo3api.Typo3Site) siteStatus {
 	return siteStatus{conditions: conditions, webStatus: common.WebStatus(t3.Status.WebStatus)}
 }
 
-func previewCreating(sc *siteapi.SiteClone, site siteStatus) string {
-	msg := fmt.Sprintf(previewCreatingMsg, sc.Name, sc.Namespace, sc.Name, sc.Spec.Clone.Name)
+func previewCreating(sc *siteapi.SiteClone, site siteStatus, bs buildStatus) string {
+	if bs.failed {
+		msg := fmt.Sprintf(siteBuildError, sc.Spec.Clone.Name, sc.Namespace, bs.failState, sc.Namespace, sc.Name, sc.Namespace, sc.Spec.Clone.Name)
+		if bs.logs != "" {
+			logs := fmt.Sprintf(siteBuildErrorLog, bs.logs)
+			msg = fmt.Sprintf("%v\n%v", msg, logs)
+		}
+		return msg
+	}
+	msg := fmt.Sprintf(previewCreatingMsg, sc.Name, sc.Namespace, sc.Namespace, sc.Name, sc.Namespace, sc.Spec.Clone.Name)
 	if err := sc.Error(); err != nil {
 		return fmt.Sprintf("**Creating preview site** %v\n**Failed:** %v", msg, err)
 	}
@@ -110,12 +147,11 @@ func previewCreating(sc *siteapi.SiteClone, site siteStatus) string {
 		return fmt.Sprintf("**Creating preview site** %v\n**Status:** %v", msg, scReadyMsg)
 	}
 	sReady, _ := common.Ready(site.conditions)
-	sn := fmt.Sprintf("%v/%v", sc.Namespace, sc.Spec.Clone.Name)
 	if !sReady {
-		return fmt.Sprintf("**Creating preview site** %v\n**Status:** Site %v is getting ready", msg, sn)
+		return fmt.Sprintf("**Creating preview site** %v\n**Status:** Site `%v` in `%v` is getting ready", msg, sc.Spec.Clone.Name, sc.Namespace)
 	}
 	if len(site.webStatus.URLs) == 0 {
-		return fmt.Sprintf("**Creating preview site** %v\n**Status:** Site %v is waiting for preview URL", msg, sn)
+		return fmt.Sprintf("**Creating preview site** %v\n**Status:** Site `%v` in `%v` is waiting for preview URL", msg, sc.Spec.Clone.Name, sc.Namespace)
 	}
 	return fmt.Sprintf("**Preview site created** %v\n**Preview URL:** %v", msg, site.webStatus.URLs[0])
 }

--- a/pkg/siteclone_watcher.go
+++ b/pkg/siteclone_watcher.go
@@ -71,18 +71,12 @@ func (w scWatcher) enqueueMsg(sc *siteapi.SiteClone) {
 	if sc.Annotations == nil || sc.Annotations[botAnnotation] != w.kubeClients.annotation {
 		return
 	}
-	msg, pr, err := w.previewSiteUpdate(sc)
+	ue, err := w.previewSiteUpdate(sc)
 	if err != nil {
 		klog.Errorf("dropping event for sc %v/%v: %v", sc.Namespace, sc.Name, err)
 		return
 	}
-	ue := UpdateEvent{
-		Message:     msg,
-		PR:          pr,
-		RepoURL:     sc.Annotations[repoAnnotation],
-		Type:        "SiteCloneUpdate",
-		Annotations: sc.Annotations,
-	}
+	ue.Type = "SiteCloneUpdate"
 	if len(w.updateEvents) == cap(w.updateEvents) {
 		klog.Errorf("dropping event %v due to channel capacity: len(%v) == cap(%v)", ue, len(w.updateEvents), cap(w.updateEvents))
 		return


### PR DESCRIPTION
This adds notification feed to github/gitlab based on the `SiteImageSource` status. When site build fails, the step that failed is shared on PR/MR to the user with up to 4kB of build logs from the step that failed.

issue: https://ddevhq.atlassian.net/browse/DEV-24
depends on: https://github.com/drud/wordpress-operator/pull/44, https://github.com/drud/ddev-live-sdk/pull/33, https://github.com/drud/site-operator/pull/401, https://github.com/drud/cms-common/pull/16