### PR TITLE
[DEV-281] Add marker to identify bot messages

### DIFF
--- a/pkg/bot.go
+++ b/pkg/bot.go
@@ -211,7 +211,7 @@ func InitBot(kubeconfig *restclient.Config, annotation, siteSuffix string, stopC
 }
 
 func (b *bot) Response(args ResponseRequest) string {
-	if isBot(args.Body) {
+	if IsBotMessage(args.Body) {
 		return ""
 	}
 	lines := strings.Split(strings.Replace(args.Body, "\r\n", "\n", -1), "\n")
@@ -241,7 +241,11 @@ func (b *bot) Response(args ResponseRequest) string {
 	for _, msg := range resp {
 		r = append(r, msg)
 	}
-	return strings.Join(r, "\n\n")
+	if len(r) == 0 {
+		return ""
+	} else {
+		return fmt.Sprintf("%v\n%v", MessageMarker, strings.Join(r, "\n\n"))
+	}
 }
 
 type ResponseRequest struct {
@@ -426,6 +430,9 @@ func (b *bot) previewSite(args ResponseRequest) string {
 
 func (b *bot) ReceiveUpdate() (UpdateEvent, error) {
 	for msg := range b.scWatcher.updateEvents {
+		if msg.Message != "" {
+			msg.Message = fmt.Sprintf("%v\n%v", MessageMarker, msg.Message)
+		}
 		return msg, nil
 	}
 	return UpdateEvent{}, io.EOF

--- a/pkg/bot.go
+++ b/pkg/bot.go
@@ -266,17 +266,17 @@ type UpdateEvent struct {
 	Annotations map[string]string
 }
 
-func repoURLNorm(url string) string {
+func RepoURLNormalize(url string) string {
 	url = strings.TrimSuffix(url, ".git")
 	u, err := git.Parse(url)
 	if err != nil {
 		return url
 	}
-	return fmt.Sprintf("%v/%v", u.Hostname(), u.Path)
+	return fmt.Sprintf("%v/%v", u.Hostname(), strings.TrimLeft(u.Path, "/"))
 }
 
 func sisMatches(sis *siteapi.SiteImageSource, repoURL, originBranch string) bool {
-	if repoURLNorm(sis.Spec.GitSource.URL) == repoURLNorm(repoURL) && sis.Spec.GitSource.Revision == originBranch {
+	if RepoURLNormalize(sis.Spec.GitSource.URL) == RepoURLNormalize(repoURL) && sis.Spec.GitSource.Revision == originBranch {
 		return true
 	}
 	parsed, err := git.Parse(repoURL)

--- a/pkg/responses.go
+++ b/pkg/responses.go
@@ -27,6 +27,9 @@ import (
 
 // These strings contain supported `/ddev-live-*` commands in PR/MR comments
 const (
+	// DDEV-Live bot message marker
+	MessageMarker = "<!-- ddev-live bot -->"
+
 	// Command prefix
 	commandPrefix = "/ddev-live-"
 
@@ -131,6 +134,10 @@ type buildStatus struct {
 	logs      string
 }
 
+func IsBotMessage(msg string) bool {
+	return strings.HasPrefix(msg, MessageMarker)
+}
+
 func getCommonStatus(t3 *typo3api.Typo3Site) siteStatus {
 	var conditions []common.Condition
 	for _, c := range t3.Status.Conditions {
@@ -170,14 +177,4 @@ func previewCreating(sc *siteapi.SiteClone, site siteStatus, bs buildStatus) str
 		return fmt.Sprintf("**Creating preview site** %v\n**Status:** Site `%v` in `%v` is waiting for preview URL", msg, sc.Spec.Clone.Name, sc.Namespace)
 	}
 	return fmt.Sprintf("**Preview site created** %v\n**Preview URL:** %v", msg, site.webStatus.URLs[0])
-}
-
-func isBot(msg string) bool {
-	if msg == helpResponse {
-		return true
-	}
-	if strings.HasPrefix(msg, deleteSiteNone) {
-		return true
-	}
-	return false
 }


### PR DESCRIPTION
With gitlab.com, users can give us PAT that is for their own account. As a result, it will appear that the bot is talking to itself and we need to clearly identify messages from user vs. messages from the bot. The marker is invisible comment in the gitlab MR note that can help us identify bot messages and use that for cleanup.

issues: https://github.com/drud/gitlab-webhook-server/issues/6 --> [DEV-281]

[DEV-281]: https://ddevhq.atlassian.net/browse/DEV-281