### PR TITLE
Prevent sending empty messages

### DIFF
--- a/pkg/bot.go
+++ b/pkg/bot.go
@@ -220,21 +220,25 @@ func (b *bot) Response(args ResponseRequest) string {
 		if !strings.HasPrefix(line, commandPrefix) {
 			continue
 		}
+		var r string
 		switch line {
 		case Ping:
-			resp[line] = pong
+			r = pong
 		case Help:
-			resp[line] = b.helpResponse(args, true)
+			r = b.helpResponse(args, true)
 		case HelpOnPROpen:
-			resp[line] = b.helpResponse(args, false)
+			r = b.helpResponse(args, false)
 		case PreviewSite:
-			resp[line] = b.previewSite(args)
+			r = b.previewSite(args)
 		case DeletePreviewSite:
-			resp[line] = b.deletePreviewSite(args, true)
+			r = b.deletePreviewSite(args, true)
 		case ClosePreviewSite:
-			resp[line] = b.deletePreviewSite(args, false)
+			r = b.deletePreviewSite(args, false)
 		default:
-			resp[line] = fmt.Sprintf("Unknown command: `%v`", line)
+			r = fmt.Sprintf("Unknown command: `%v`", line)
+		}
+		if len(r) != 0 {
+			resp[line] = r
 		}
 	}
 	var r []string


### PR DESCRIPTION
Reported in https://drud.slack.com/archives/C66FHURFG/p1605707462004400

<img width="974" alt="fix_description_of_https_expose_by_liayn____pull_request__2646____drud_ddev" src="https://user-images.githubusercontent.com/1529535/99545556-cb350100-29b5-11eb-8530-2edb1ac56f5f.png">

Broken in https://github.com/drud/repo-chat-bot/pull/10, bot treats empty message containing only a marker as still worth sending out and they look pretty empty, but we don't want them to be sent out at all.