### PR TITLE
[DEV-299] Update error message when SiteClone status changes

### DIFF
--- a/pkg/responses.go
+++ b/pkg/responses.go
@@ -163,7 +163,8 @@ func previewCreating(sc *siteapi.SiteClone, site siteStatus, bs buildStatus) str
 	}
 	msg := fmt.Sprintf(previewCreatingMsg, sc.Name, sc.Namespace, sc.Namespace, sc.Name, sc.Namespace, sc.Spec.Clone.Name)
 	if err := sc.Error(); err != nil {
-		return fmt.Sprintf("**Creating preview site** %v\n**Failed:** %v", msg, err)
+		errLog := fmt.Sprintf(siteBuildErrorLog, err)
+		return fmt.Sprintf("**Creating preview site** %v\n**Failed**\n%v", msg, errLog)
 	}
 	scReady, scReadyMsg := sc.Ready()
 	if !scReady {

--- a/pkg/siteclone_watcher.go
+++ b/pkg/siteclone_watcher.go
@@ -46,7 +46,7 @@ func (w scWatcher) OnUpdate(oldObj, newObj interface{}) {
 	}
 	nr, nm := n.Ready()
 	or, om := o.Ready()
-	if nr == or && nm == om {
+	if nr == or && nm == om && n.Error() == o.Error() {
 		return
 	}
 	w.enqueueMsg(o)


### PR DESCRIPTION
## Issue ID(s):
When we create `SiteClone`, the bot identifies the status as not finished and informs the user about the tasks that are still pending. When `SiteClone` hits something it can't resolve, it sets an error to its status condition but it would take a very long time to be propagated all the way to the PR. Cloning issues, such as hitting the site quota, would rarely get to the user without an extensive delay. This PR fixes the unnecessary delay in the update of `SiteClone` status.

catch-em-all issue: https://ddevhq.atlassian.net/browse/DEV-299

## Tests:
<!-- Tests introduced by this PR, manual steps to validate the fix, or an explanation for why no tests are needed. -->

## Release/Deployment notes:
<!-- Are there ramifications to other code? Does anything have to be done on deployment? -->
