### PR TITLE
Provide better message when a user is missing public email

### DIFF
--- a/pkg/bot.go
+++ b/pkg/bot.go
@@ -480,6 +480,10 @@ func (b *bot) previewSite(args ResponseRequest) string {
 			klog.Errorf("failed to find site for SiteImageSource %v/%v: %v", sis.Namespace, sis.Name, err)
 			continue
 		}
+		if args.Email == "" {
+			msgs = append(msgs, previewDeniedMissingEmail)
+			continue
+		}
 		if allow, err := b.hasPreviewSiteCapability(args.Email, sis.Namespace); err != nil {
 			msgs = append(msgs, previewGenericError)
 			continue

--- a/pkg/responses.go
+++ b/pkg/responses.go
@@ -69,6 +69,9 @@ const (
 	// logs will contain more information about the reason why user has been denied if it is anything else except user missing SiteEditor capability
 	previewDenied = "**Unauthorized** `%v` preview site command, please contact your DDEV-Live account owner for `%v`"
 
+	// Preview missing email is a message that preview bot sends when user doesn't have their email configured for their account and we can't validate their authorization
+	previewDeniedMissingEmail = "**Unauthorized** preview site command. Please configure public email for your account"
+
 	// Generic error when site cloning failed. We don't want to expose internal details on PR comments,
 	// logs will contain more information about what failed
 	previewGenericError = "**Internal error** creating preview sites"


### PR DESCRIPTION
## Issue ID(s):

@jdarrohn had stumbled upon an interesting problem with the preview bot. In GitHub, you can hide your email for your account. We use that email to figure out whether a user is authorized to create sites in a particular namespace.

I think the best course of action is to provide better error message explaining the problem to the user and append the docs to explain that if you want to use the preview bot, you should make your GitHub email publicly visible. 

Potentially in parallel, we can try to figure out a different way to check user capabilities than just from the email, we will always receive their GitHub account name fwiw.

## Tests:
<!-- Tests introduced by this PR, manual steps to validate the fix, or an explanation for why no tests are needed. -->

## Release/Deployment notes:
<!-- Are there ramifications to other code? Does anything have to be done on deployment? -->
