### PR TITLE
[DEV-329] Metrics and analytics for bot commands

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/drud/admin-api v0.4.2
 	github.com/drud/cms-common v0.0.7
 	github.com/drud/ddev-live-sdk v0.2.8
+	github.com/prometheus/client_golang v1.7.1
 	github.com/whilp/git-urls v1.0.0
 	google.golang.org/grpc v1.29.1
 	k8s.io/api v0.17.9

--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,16 @@ module github.com/drud/repo-chat-bot
 go 1.15
 
 require (
+	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
 	github.com/drud/admin-api v0.4.2
 	github.com/drud/cms-common v0.0.7
 	github.com/drud/ddev-live-sdk v0.2.8
 	github.com/prometheus/client_golang v1.7.1
+	github.com/segmentio/backo-go v0.0.0-20160424052352-204274ad699c // indirect
 	github.com/whilp/git-urls v1.0.0
+	github.com/xtgo/uuid v0.0.0-20140804021211-a0b114877d4c // indirect
 	google.golang.org/grpc v1.29.1
+	gopkg.in/segmentio/analytics-go.v3 v3.0.1
 	k8s.io/api v0.17.9
 	k8s.io/apimachinery v0.18.5
 	k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible

--- a/go.sum
+++ b/go.sum
@@ -112,6 +112,8 @@ github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
+github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
+github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/bradleyfalzon/ghinstallation v1.1.1/go.mod h1:vyCmHTciHx/uuyN82Zc3rXN3X2KTK8nUTCrTMwAhcug=
 github.com/census-instrumentation/opencensus-proto v0.2.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -601,6 +603,8 @@ github.com/ryanuber/columnize v2.1.0+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFo
 github.com/ryanuber/go-glob v1.0.0/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sclevine/spec v1.2.0/go.mod h1:W4J29eT/Kzv7/b9IWLB055Z+qvVC9vt0Arko24q7p+U=
+github.com/segmentio/backo-go v0.0.0-20160424052352-204274ad699c h1:rsRTAcCR5CeNLkvgBVSjQoDGRRt6kggsE6XYBqCv2KQ=
+github.com/segmentio/backo-go v0.0.0-20160424052352-204274ad699c/go.mod h1:kJ9mm9YmoWSkk+oQ+5Cj8DEoRCX2JT6As4kEtIIOp1M=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/shurcooL/githubv4 v0.0.0-20190718010115-4ba037080260/go.mod h1:hAF0iLZy4td2EX+/8Tw+4nodhlMrwN3HupfaXj3zkGo=
 github.com/shurcooL/githubv4 v0.0.0-20191102174205-af46314aec7b/go.mod h1:hAF0iLZy4td2EX+/8Tw+4nodhlMrwN3HupfaXj3zkGo=
@@ -658,6 +662,8 @@ github.com/xdg/stringprep v1.0.0/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0
 github.com/xiang90/probing v0.0.0-20160813154853-07dd2e8dfe18/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
+github.com/xtgo/uuid v0.0.0-20140804021211-a0b114877d4c h1:3lbZUMbMiGUW/LMkfsEABsc5zNT9+b1CvsJx47JzJ8g=
+github.com/xtgo/uuid v0.0.0-20140804021211-a0b114877d4c/go.mod h1:UrdRz5enIKZ63MEE3IF9l2/ebyx59GyGgPi+tICQdmM=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
@@ -1046,6 +1052,8 @@ gopkg.in/jcmturner/gokrb5.v7 v7.3.0/go.mod h1:l8VISx+WGYp+Fp7KRbsiUuXTTOnxIc3Tuv
 gopkg.in/jcmturner/rpc.v1 v1.1.0/go.mod h1:YIdkC4XfD6GXbzje11McwsDuOlZQSb9W4vfLvuNnlv8=
 gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
+gopkg.in/segmentio/analytics-go.v3 v3.0.1 h1:lPX/m/RnUFwu33p/1vRx4O3aexmrS6vB8OkIiXnPgAw=
+gopkg.in/segmentio/analytics-go.v3 v3.0.1/go.mod h1:4QqqlTlSSpVlWA9/9nDcPw+FkM2yv1NQoYjUbL9/JAw=
 gopkg.in/square/go-jose.v2 v2.2.2/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/square/go-jose.v2 v2.3.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/src-d/go-billy.v4 v4.3.2/go.mod h1:nDjArDMp+XMs1aFAESLRjfGSgfvoYN0hDfzEk0GjC98=

--- a/pkg/bot.go
+++ b/pkg/bot.go
@@ -78,6 +78,16 @@ var (
 	logLimitBytes       = int64(4 * 1024)
 )
 
+type Config struct {
+	Kubeconfig     *restclient.Config
+	Annotation     string
+	SiteSuffix     string
+	AuthSVCLabels  string
+	StopCh         <-chan struct{}
+	AnalyticsKey   string
+	AnalyticsAppId string
+}
+
 type Bot interface {
 	Response(args ResponseRequest) string
 	ReceiveUpdate() (UpdateEvent, error)
@@ -87,6 +97,7 @@ type bot struct {
 	scWatcher    scWatcher
 	cmsWatcher   cmsWatcher
 	updateEvents chan UpdateEvent
+	analytics    *analytics
 
 	kubeClients
 }
@@ -149,24 +160,25 @@ func authAdminAPI(k *kubernetes.Clientset, authSVCLabels string) (pbAdmin.Admini
 	return pbAdmin.NewAdministrationClient(conn), nil
 }
 
-func InitBot(kubeconfig *restclient.Config, annotation, siteSuffix string, authSVCLabels string, stopCh <-chan struct{}) (Bot, error) {
-	scs, err := siteclientset.NewForConfig(kubeconfig)
+func InitBot(bc Config) (Bot, error) {
+	analytics := AnalyticsClient(bc.Annotation, bc.AnalyticsAppId, bc.AnalyticsKey)
+	scs, err := siteclientset.NewForConfig(bc.Kubeconfig)
 	if err != nil {
 		return nil, err
 	}
-	drupal, err := drupalclientset.NewForConfig(kubeconfig)
+	drupal, err := drupalclientset.NewForConfig(bc.Kubeconfig)
 	if err != nil {
 		return nil, err
 	}
-	typo3, err := typo3clientset.NewForConfig(kubeconfig)
+	typo3, err := typo3clientset.NewForConfig(bc.Kubeconfig)
 	if err != nil {
 		return nil, err
 	}
-	wordpress, err := wordpressclientset.NewForConfig(kubeconfig)
+	wordpress, err := wordpressclientset.NewForConfig(bc.Kubeconfig)
 	if err != nil {
 		return nil, err
 	}
-	kcs, err := kubernetes.NewForConfig(kubeconfig)
+	kcs, err := kubernetes.NewForConfig(bc.Kubeconfig)
 	if err != nil {
 		return nil, err
 	}
@@ -190,7 +202,7 @@ func InitBot(kubeconfig *restclient.Config, annotation, siteSuffix string, authS
 
 	kf := kubefactory.NewSharedInformerFactory(kcs, defaultResyncPeriod)
 	podLister := kf.Core().V1().Pods().Lister()
-	adminClient, err := authAdminAPI(kcs, authSVCLabels)
+	adminClient, err := authAdminAPI(kcs, bc.AuthSVCLabels)
 	if err != nil {
 		return nil, err
 	}
@@ -198,8 +210,8 @@ func InitBot(kubeconfig *restclient.Config, annotation, siteSuffix string, authS
 	updateEvents := make(chan UpdateEvent, chanSize)
 
 	kubeClients := kubeClients{
-		annotation:    annotation,
-		siteSuffix:    siteSuffix,
+		annotation:    bc.Annotation,
+		siteSuffix:    bc.SiteSuffix,
 		wait:          make(chan bool, 1),
 		siteClientSet: scs,
 		sisInformer:   sisInformer,
@@ -229,16 +241,16 @@ func InitBot(kubeconfig *restclient.Config, annotation, siteSuffix string, authS
 	tInformer.AddEventHandler(cmsWatcher)
 	wInformer.AddEventHandler(cmsWatcher)
 
-	df.Start(stopCh)
-	tf.Start(stopCh)
-	wf.Start(stopCh)
-	sf.Start(stopCh)
-	kf.Start(stopCh)
-	df.WaitForCacheSync(stopCh)
-	tf.WaitForCacheSync(stopCh)
-	wf.WaitForCacheSync(stopCh)
-	sf.WaitForCacheSync(stopCh)
-	kf.WaitForCacheSync(stopCh)
+	df.Start(bc.StopCh)
+	tf.Start(bc.StopCh)
+	wf.Start(bc.StopCh)
+	sf.Start(bc.StopCh)
+	kf.Start(bc.StopCh)
+	df.WaitForCacheSync(bc.StopCh)
+	tf.WaitForCacheSync(bc.StopCh)
+	wf.WaitForCacheSync(bc.StopCh)
+	sf.WaitForCacheSync(bc.StopCh)
+	kf.WaitForCacheSync(bc.StopCh)
 	close(kubeClients.wait)
 
 	return &bot{
@@ -246,6 +258,7 @@ func InitBot(kubeconfig *restclient.Config, annotation, siteSuffix string, authS
 		cmsWatcher:   cmsWatcher,
 		updateEvents: updateEvents,
 		kubeClients:  kubeClients,
+		analytics:    analytics,
 	}, nil
 }
 
@@ -388,10 +401,10 @@ func siteClone(site metav1.Object, cloneBranch string, pr int, annotations map[s
 func (b *bot) helpResponse(args ResponseRequest, verbose bool) string {
 	if verbose {
 		// display bot help message when user asks for it even when there are no origin to clone from
-		HelpPreviewSiteCounter.WithLabelValues(b.annotation, b.siteSuffix).Inc()
+		b.analytics.ObserveHelp(args.Email, metricLabelCommand)
 		return helpResponse
 	}
-	HelpPreviewSiteCounter.WithLabelValues(b.annotation, metricLabelCommand).Inc()
+	b.analytics.ObserveHelp(args.Email, b.siteSuffix)
 
 	list, err := b.sisLister.List(labels.Everything())
 	if err != nil {
@@ -416,22 +429,22 @@ func (b *bot) deletePreviewSite(args ResponseRequest, verboseErrors bool) string
 	if err != nil {
 		klog.Errorf("failed listing SiteClones: %v", err)
 		if verboseErrors {
+			b.analytics.ObserveDeletePreviewSite(args.Email, ml, metricLabelPreviewFailed)
 			return previewGenericError
 		} else {
 			return ""
 		}
-		DeletePreviewSiteCounter.WithLabelValues(b.annotation, ml, metricLabelPreviewFailed).Inc()
 	}
 	filtered := filterSc(list, args.RepoURL, args.PR)
 	var msgs []string
 	for _, sc := range filtered {
 		if verboseErrors {
 			if allow, err := b.hasPreviewSiteCapability(args.Email, sc.Namespace); err != nil {
-				DeletePreviewSiteCounter.WithLabelValues(b.annotation, ml, metricLabelPreviewAuthAPIError).Inc()
+				b.analytics.ObserveDeletePreviewSite(args.Email, ml, metricLabelPreviewAuthAPIError)
 				msgs = append(msgs, previewGenericError)
 				continue
 			} else if !allow {
-				DeletePreviewSiteCounter.WithLabelValues(b.annotation, ml, metricLabelPreviewDenied).Inc()
+				b.analytics.ObserveDeletePreviewSite(args.Email, ml, metricLabelPreviewDenied)
 				msgs = append(msgs, fmt.Sprintf(previewDenied, args.Email, sc.Namespace))
 				continue
 			}
@@ -442,14 +455,15 @@ func (b *bot) deletePreviewSite(args ResponseRequest, verboseErrors bool) string
 			if verboseErrors {
 				msgs = append(msgs, fmt.Sprintf(deleteSiteError, sc.Spec.Clone.Name, sc.Namespace))
 			}
-			DeletePreviewSiteCounter.WithLabelValues(b.annotation, ml, metricLabelPreviewFailed).Inc()
+			b.analytics.ObserveDeletePreviewSite(args.Email, ml, metricLabelPreviewFailed)
 		} else if err == nil {
 			// no error, we have successfully deleted SiteClone
-			DeletePreviewSiteCounter.WithLabelValues(b.annotation, ml, metricLabelPreviewSuccess).Inc()
+			b.analytics.ObserveDeletePreviewSite(args.Email, ml, metricLabelPreviewSuccess)
 			msgs = append(msgs, fmt.Sprintf(deleteSite, sc.Spec.Clone.Name, sc.Namespace))
 		}
 	}
 	if len(msgs) == 0 && verboseErrors {
+		b.analytics.ObserveDeletePreviewSite(args.Email, ml, metricLabelPreviewNothingToDelete)
 		return fmt.Sprintf("%v\n___\n%v", deleteSiteNone, helpResponse)
 	}
 	return strings.Join(msgs, "\n\n")
@@ -476,13 +490,13 @@ func (b *bot) hasPreviewSiteCapability(email, org string) (bool, error) {
 
 func (b *bot) previewSite(args ResponseRequest) string {
 	if args.Email == "" {
-		CreatePreviewSiteCounter.WithLabelValues(b.annotation, metricLabelPreviewDeniedMissingEmail).Inc()
+		b.analytics.ObserveCreatePreviewSite(args.Email, metricLabelPreviewDeniedMissingEmail)
 		return previewDeniedMissingEmail
 	}
 	list, err := b.sisLister.List(labels.Everything())
 	if err != nil {
 		klog.Errorf("failed listing SiteImageSource: %v", err)
-		CreatePreviewSiteCounter.WithLabelValues(b.annotation, metricLabelPreviewFailed).Inc()
+		b.analytics.ObserveCreatePreviewSite(args.Email, metricLabelPreviewFailed)
 		return previewGenericError
 	}
 	filtered := filterSis(list, args.RepoURL, args.OriginBranch)
@@ -498,16 +512,16 @@ func (b *bot) previewSite(args ResponseRequest) string {
 		}
 		if allow, err := b.hasPreviewSiteCapability(args.Email, sis.Namespace); err != nil {
 			msgs = append(msgs, previewGenericError)
-			CreatePreviewSiteCounter.WithLabelValues(b.annotation, metricLabelPreviewAuthAPIError).Inc()
+			b.analytics.ObserveCreatePreviewSite(args.Email, metricLabelPreviewAuthAPIError)
 			continue
 		} else if !allow {
 			msgs = append(msgs, fmt.Sprintf(previewDenied, args.Email, sis.Namespace))
-			CreatePreviewSiteCounter.WithLabelValues(b.annotation, metricLabelPreviewDenied).Inc()
+			b.analytics.ObserveCreatePreviewSite(args.Email, metricLabelPreviewDenied)
 			continue
 		}
 		siteclone := siteClone(site, args.CloneBranch, args.PR, args.Annotations, b.siteSuffix)
 		if sc, err := b.scLister.SiteClones(siteclone.Namespace).Get(siteclone.Name); err == nil {
-			CreatePreviewSiteCounter.WithLabelValues(b.annotation, metricLabelPreviewSuccess).Inc()
+			b.analytics.ObserveCreatePreviewSite(args.Email, metricLabelPreviewSuccess)
 			ue, _ := b.previewSiteUpdate(sc)
 			msgs = append(msgs, ue.Message)
 			continue
@@ -515,15 +529,15 @@ func (b *bot) previewSite(args ResponseRequest) string {
 		if sc, err := b.siteClientSet.SiteV1beta1().SiteClones(sis.Namespace).Create(siteclone); err != nil {
 			if !kerrors.IsAlreadyExists(err) {
 				klog.Errorf("failed to create site clone %v: %v", siteclone, err)
-				CreatePreviewSiteCounter.WithLabelValues(b.annotation, metricLabelPreviewFailed).Inc()
+				b.analytics.ObserveCreatePreviewSite(args.Email, metricLabelPreviewFailed)
 				msgs = append(msgs, fmt.Sprintf(previewSiteError, siteclone.Spec.Origin.Name))
 				continue
 			}
-			CreatePreviewSiteCounter.WithLabelValues(b.annotation, metricLabelPreviewSuccess).Inc()
+			b.analytics.ObserveCreatePreviewSite(args.Email, metricLabelPreviewSuccess)
 			ue, _ := b.previewSiteUpdate(sc)
 			msgs = append(msgs, ue.Message)
 		} else {
-			CreatePreviewSiteCounter.WithLabelValues(b.annotation, metricLabelPreviewSuccess).Inc()
+			b.analytics.ObserveCreatePreviewSite(args.Email, metricLabelPreviewSuccess)
 			ue, _ := b.previewSiteUpdate(sc)
 			msgs = append(msgs, ue.Message)
 		}

--- a/pkg/metrics.go
+++ b/pkg/metrics.go
@@ -1,0 +1,50 @@
+/*
+Copyright DDEV Technologies LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pkg
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// Prometheus metrics for bot command invocations
+var (
+	CreatePreviewSiteCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "bot_create_preview_site_total",
+		Help: "Total number of create preview site command invocations",
+	}, []string{"bot", "status"})
+
+	DeletePreviewSiteCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "bot_delete_preview_site_total",
+		Help: "Total number of delete preview site command invocations",
+	}, []string{"bot", "action", "status"})
+
+	HelpPreviewSiteCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "bot_help_preview_site_total",
+		Help: "Total number of help command invocations",
+	}, []string{"bot", "action"})
+
+	// Label for counters that can be triggered either by command directly or action in a repository
+	metricLabelCommand = "command"
+
+	// Labels for site creation status
+	metricLabelPreviewSuccess            = "success"
+	metricLabelPreviewFailed             = "internal error"
+	metricLabelPreviewDeniedMissingEmail = "failed to verify user email"
+	metricLabelPreviewAuthAPIError       = "failed to query admin API"
+	metricLabelPreviewDenied             = "unauthorized"
+)

--- a/pkg/metrics.go
+++ b/pkg/metrics.go
@@ -17,8 +17,12 @@ limitations under the License.
 package pkg
 
 import (
+	"k8s.io/klog"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	segment "gopkg.in/segmentio/analytics-go.v3"
 )
 
 // Prometheus metrics for bot command invocations
@@ -47,4 +51,110 @@ var (
 	metricLabelPreviewDeniedMissingEmail = "failed to verify user email"
 	metricLabelPreviewAuthAPIError       = "failed to query admin API"
 	metricLabelPreviewDenied             = "unauthorized"
+	metricLabelPreviewNothingToDelete    = "no preview site to be deleted"
 )
+
+type analytics struct {
+	botType string
+	appId   string
+	cli     segment.Client
+}
+
+type noopLog struct{}
+
+func (n *noopLog) Logf(f string, args ...interface{})   {}
+func (n *noopLog) Errorf(f string, args ...interface{}) {}
+
+func AnalyticsClient(botType, appId, writeKey string) *analytics {
+	if writeKey == "" {
+		klog.Info("analytics client not configured")
+		return &analytics{
+			botType: botType,
+			appId:   appId,
+		}
+	}
+	cli, err := segment.NewWithConfig(writeKey, segment.Config{Logger: &noopLog{}})
+	if err != nil {
+		klog.Errorf("failed to init analytics client: %v", err)
+	}
+	return &analytics{
+		botType: botType,
+		appId:   appId,
+		cli:     cli,
+	}
+}
+
+func (a *analytics) ObserveCreatePreviewSite(user, result string) {
+	CreatePreviewSiteCounter.WithLabelValues(a.botType, result).Inc()
+	if a.cli == nil {
+		klog.V(9).Info("analytics client disabled")
+		return
+	}
+	props := segment.NewProperties()
+	props.Set("result", result)
+	props.Set("type", metricLabelCommand)
+	props.Set("bot", a.botType)
+	msg := segment.Track{
+		UserId:     user,
+		Event:      PreviewSite,
+		Properties: props,
+		Context: &segment.Context{
+			App: segment.AppInfo{
+				Name: a.appId,
+			},
+		},
+	}
+	if err := a.cli.Enqueue(msg); err != nil {
+		klog.Errorf("failed to send analytics for create preview site: %v", err)
+	}
+}
+
+func (a *analytics) ObserveDeletePreviewSite(user, t, result string) {
+	DeletePreviewSiteCounter.WithLabelValues(a.botType, t, result).Inc()
+	if a.cli == nil {
+		klog.V(9).Info("analytics client disabled")
+		return
+	}
+	props := segment.NewProperties()
+	props.Set("result", result)
+	props.Set("type", t)
+	props.Set("bot", a.botType)
+	msg := segment.Track{
+		UserId:     user,
+		Event:      DeletePreviewSite,
+		Properties: props,
+		Context: &segment.Context{
+			App: segment.AppInfo{
+				Name: a.appId,
+			},
+		},
+	}
+	if err := a.cli.Enqueue(msg); err != nil {
+		klog.Errorf("failed to send analytics for delete preview site: %v", err)
+	}
+}
+
+func (a *analytics) ObserveHelp(user, t string) {
+	HelpPreviewSiteCounter.WithLabelValues(a.botType, t).Inc()
+	if a.cli == nil {
+		klog.V(9).Info("analytics client disabled")
+		return
+	}
+	props := segment.NewProperties()
+	props.Set("result", "success")
+	props.Set("type", t)
+	props.Set("bot", a.botType)
+	msg := segment.Track{
+		UserId:     user,
+		Event:      Help,
+		Properties: props,
+		Context: &segment.Context{
+			App: segment.AppInfo{
+				Name: a.appId,
+			},
+		},
+	}
+	if err := a.cli.Enqueue(msg); err != nil {
+		klog.Errorf("failed to send analytics for help preview site: %v", err)
+	}
+}


### PR DESCRIPTION
## Issue ID(s):
https://ddevhq.atlassian.net/browse/DEV-329

We would like to have some insight into how many times the preview bot commands have been invoked, similar to how we measure CLI or UI or API calls. This tracks all three preview bot commands and groups them into few error / success groups.

There are two sinks for these metrics:
* prometheus `ServiceMonitor`
* segment / amplitude analytics

## Tests:
<!-- Tests introduced by this PR, manual steps to validate the fix, or an explanation for why no tests are needed. -->

## Release/Deployment notes:
<!-- Are there ramifications to other code? Does anything have to be done on deployment? -->
example for prometheus metrics:
```
$ curl --silent localhost:8080/metrics  | grep bot
# HELP bot_create_preview_site_total Total number of create preview site command invocations
# TYPE bot_create_preview_site_total counter
bot_create_preview_site_total{bot="github-operator",status="success"} 1
# HELP bot_help_preview_site_total Total number of help command invocations
# TYPE bot_help_preview_site_total counter
bot_help_preview_site_total{action="command",bot="github-operator"} 1
bot_help_preview_site_total{action="pr",bot="github-operator"} 1
```

example for analytics avent as taken from segment
```go
client.Track(&analytics.Track{
  UserId: "wozniak.jan@gmail.com",      // the user email as we receive it from github / gitlab
  Event: "/ddev-live-help",             // the command they executed with the bot
  Properties: map[string]interface{}{
    "bot": "github-operator",           // github or gitlab bot
    "result": "success",                // whether the bot succe
    "type": "pr",                       // either "pr" or "command", whether the action was triggered by the user typing the command or whether it was auto triggered by PR open / close
  },
})
```