### PR TITLE
[DEV-550] Separate auto-trigger from commands

### DIFF
--- a/pkg/bot.go
+++ b/pkg/bot.go
@@ -297,7 +297,8 @@ func (b *bot) Response(args ResponseRequest) string {
 	if IsBotMessage(args.Body) {
 		return ""
 	}
-	resp := b.response(args, args.Body)
+	all := fmt.Sprintf("%v\n%v", args.Title, args.Body)
+	resp := b.response(args, all)
 	if len(resp) == 0 {
 		resp = b.response(args, args.Trigger)
 	}
@@ -314,6 +315,7 @@ func (b *bot) Response(args ResponseRequest) string {
 
 type ResponseRequest struct {
 	Email        string
+	Title        string
 	Body         string
 	Trigger      string
 	RepoURL      string


### PR DESCRIPTION
## Issue ID(s):
https://ddevhq.atlassian.net/browse/DEV-550
We would like to trigger bot commands on PRs directly without the requirement of putting commands in a followup comment. This allows the upstream clients to configure automatic trigger independently of direct user commands which is a prerequisite for responding on PR commands directly.

## Tests:
<!-- Tests introduced by this PR, manual steps to validate the fix, or an explanation for why no tests are needed. -->

## Release/Deployment notes:
<!-- Are there ramifications to other code? Does anything have to be done on deployment? -->
