### PR TITLE
Derive workspace name from namespace labels

### DIFF
--- a/config/rbac.yaml
+++ b/config/rbac.yaml
@@ -32,6 +32,7 @@ rules:
   - pods
   - pods/log
   - services
+  - namespaces
   verbs:
   - get
   - list

--- a/pkg/bot.go
+++ b/pkg/bot.go
@@ -225,6 +225,7 @@ func InitBot(bc Config) (Bot, error) {
 		wLister:       wLister,
 		wInformer:     wInformer,
 		podLister:     podLister,
+		nsLister:      nsLister,
 		coreClientSet: kcs,
 		authClient:    adminClient,
 	}


### PR DESCRIPTION
## Issue ID(s):
The new style workspaces have different way of figuring out a namespace. This PR should ensure both old style orgs as well as new style workspaces work.

## Tests:
<!-- Tests introduced by this PR, manual steps to validate the fix, or an explanation for why no tests are needed. -->

## Release/Deployment notes:
<!-- Are there ramifications to other code? Does anything have to be done on deployment? -->
